### PR TITLE
feat: single-locale mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Localize your Webpack bundle with multiple locales.
 
 ### Features
 - Create bundles with localization baked in
-- Suports multiple locales
+- Suports single & multiple locales
 - Blazing fast!
 
 _How does it compare to [i18n-webpack-plugin](https://github.com/webpack-contrib/i18n-webpack-plugin)?_ Answered in the [FAQ](#how-does-this-compare-to-a-href-https-github-com-webpack-contrib-i18n-webpack-plugin-i18n-webpack-plugin-a-).
@@ -95,8 +95,16 @@ The function name to use to detect localization string keys.
 const message = __('helloWorld'); // => 'Hello world!'
 ```
 #### throwOnMissing
+Type: `boolean`
+
+Default: `false`
+
 Throw an error if a string key is not found in a locale object.
 
+#### sourceMapsForLocales
+Type: `string[]`
+
+An array of locales that source-maps should be emitted for. Source-maps are enabled via [`devtool`](https://webpack.js.org/configuration/devtool/).
 
 ## 💁‍♀️ FAQ
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -252,7 +252,11 @@ class LocalizeAssetsPlugin implements Plugin {
 							localizationReplacements,
 							localePlaceholderLocations,
 							sourceString,
-							map,
+							(
+								(!sourceMapsForLocales || sourceMapsForLocales.includes(locale))
+									? map
+									: null
+							),
 						);
 
 						// @ts-expect-error Outdated @type

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,7 +142,7 @@ class LocalizeAssetsPlugin implements Plugin {
 				}
 				const location = callExpressionNode.loc.start;
 				const error = new WebpackError(
-					`Confusing usage of localization function "${functionName}" in ${parser.state.module.resource}:${location.line}:${location.column}`,
+					`Ignoring confusing usage of localization function "${functionName}" in ${parser.state.module.resource}:${location.line}:${location.column}`,
 				);
 				compilation.warnings.push(error);
 			});

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,9 @@ export const OptionsSchema = z.object({
 }).refine(options => (
 	!options.sourceMapsForLocales
 	|| options.sourceMapsForLocales.every(locale => hasOwnProp(options.locales, locale))
-));
+), {
+	message: 'sourceMapsForLocales must contain valid locales',
+});
 
 export type Options = z.infer<typeof OptionsSchema>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import type WP4 from 'webpack';
 import type WP5 from 'webpack5';
 import * as z from 'zod';
+import hasOwnProp from 'has-own-prop';
 
 const LocaleSchema = z.record(z.string());
 const LocalesSchema = z.record(LocaleSchema).refine(
@@ -14,7 +15,11 @@ export const OptionsSchema = z.object({
 	locales: LocalesSchema,
 	functionName: z.string().optional(),
 	throwOnMissing: z.boolean().optional(),
-});
+	sourceMapsForLocales: z.string().array().optional(),
+}).refine(options => (
+	!options.sourceMapsForLocales
+	|| options.sourceMapsForLocales.every(locale => hasOwnProp(options.locales, locale))
+));
 
 export type Options = z.infer<typeof OptionsSchema>;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,3 +37,28 @@ export const { toConstantDependency } = (
 		? require('webpack/lib/javascript/JavascriptParserHelpers') // eslint-disable-line node/global-require,import/no-unresolved
 		: require('webpack/lib/ParserHelpers') // eslint-disable-line node/global-require
 );
+
+export const deleteAsset = (
+	compilation: Compilation,
+	assetName: string,
+	newAssetNames: string[],
+) => {
+	// Delete original unlocalized asset
+	if (isWebpack5Compilation(compilation)) {
+		compilation.deleteAsset(assetName);
+	} else {
+		delete compilation.assets[assetName];
+
+		/**
+		 * To support terser-webpack-plugin v1.4.5 (bundled with Webpack 4)
+		 * which iterates over chunks instead of assets
+		 * https://github.com/webpack-contrib/terser-webpack-plugin/blob/v1.4.5/src/index.js#L176
+		 */
+		for (const chunk of compilation.chunks) {
+			const hasAsset = chunk.files.indexOf(assetName);
+			if (hasAsset > -1) {
+				chunk.files.splice(hasAsset, 1, ...newAssetNames);
+			}
+		}
+	}
+};

--- a/tests/webpack-localize-assets-plugin.spec.ts
+++ b/tests/webpack-localize-assets-plugin.spec.ts
@@ -217,8 +217,8 @@ describe(`Webpack ${webpack.version}`, () => {
 
 			expect(buildStats.hasWarnings()).toBe(true);
 			expect(buildStats.compilation.warnings.length).toBe(2);
-			expect(buildStats.compilation.warnings[0].message).toMatch('Confusing usage of localization function "__" in /src/index.js:3:7');
-			expect(buildStats.compilation.warnings[1].message).toMatch('Confusing usage of localization function "__" in /src/index.js:4:7');
+			expect(buildStats.compilation.warnings[0].message).toMatch('Ignoring confusing usage of localization function "__" in /src/index.js:3:7');
+			expect(buildStats.compilation.warnings[1].message).toMatch('Ignoring confusing usage of localization function "__" in /src/index.js:4:7');
 		});
 	});
 

--- a/tests/webpack-localize-assets-plugin.spec.ts
+++ b/tests/webpack-localize-assets-plugin.spec.ts
@@ -208,6 +208,24 @@ describe(`Webpack ${webpack.version}`, () => {
 			expect(buildStats.compilation.warnings[0].message).toMatch('Ignoring confusing usage of localization function "__" in /src/index.js:3:7');
 			expect(buildStats.compilation.warnings[1].message).toMatch('Ignoring confusing usage of localization function "__" in /src/index.js:4:7');
 		});
+
+		test('sourceMapsForLocales - invalid locale', async () => {
+			await expect(async () => {
+				await build(
+					{
+						'/src/index.js': '',
+					},
+					(config) => {
+						config.plugins!.push(
+							new WebpackLocalizeAssetsPlugin({
+								locales: localesSingle,
+								sourceMapsForLocales: ['non-existent-locale'],
+							}),
+						);
+					},
+				);
+			}).rejects.toThrow('sourceMapsForLocales must contain valid locales');
+		});
 	});
 
 	describe('passing', () => {


### PR DESCRIPTION
- Added "single locale mode" which doesn't insert placeholders if only one placeholder is passed in. Instead, it directly inserts the locale and skips the post-processing step.
- Added a `sourceMapsForLocales` option to ignore sourcemaps for specific locales.