### PR TITLE
Fix astring import bug

### DIFF
--- a/src/utils/stringify-ast.ts
+++ b/src/utils/stringify-ast.ts
@@ -1,8 +1,6 @@
-import * as astring from 'astring';
+import { generate } from 'astring';
 import type { Node } from 'estree';
 
 const astringOptions = Object.freeze({ indent: '', lineEnd: '' });
 
-export function stringifyAst(ast: Node) {
-	return astring.generate(ast, astringOptions);
-}
+export const stringifyAst = (ast: Node) => generate(ast, astringOptions);

--- a/src/utils/stringify-ast.ts
+++ b/src/utils/stringify-ast.ts
@@ -1,4 +1,4 @@
-import astring from 'astring';
+import * as astring from 'astring';
 import type { Node } from 'estree';
 
 const astringOptions = Object.freeze({ indent: '', lineEnd: '' });


### PR DESCRIPTION
* astring is an `__esModule`-type module with no `default` export
* TypeScript emits code roughly equivalent to `require('astring').default` when the required module is an `__esModule`
* I encountered the bug when trying to run the NPM-distributed version of the plugin in my code
* I don't know why TypeScript allowed me to write `import astring` without an error, and I don't know why it behaves correctly in the test harness but the compiled code is wrong.
    * `astring`'s `d.ts` file uses ESM syntax, so TypeScript should know that there's no default export?
    * I do get a type error if I disable `esModuleInterop`.

Steps to reproduce:

* Install v1.4.0 from NPM and try to run it
* I get an exception from `stringifyAst` ("cannot read properties of undefined").
    * The generated JS code says `astring_1.default.generate(ast, astringOptions)`.
    * With this fix it says `astring.generate(ast, astringOptions);` (no `default`).
    * It was a bit tricky to track down the exception, because it happens in the Webpack pipeline. I had to run in the debugger to find it. Your mileage may vary