### PR TITLE
fix: address deprecation warning with Chunk.getModules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -132,7 +132,9 @@ class LocalizeAssetsPlugin<LocalizedData = string> {
 
 					// Update chunkHash based on localized content
 					compilation.hooks.chunkHash.tap(name, (chunk, hash) => {
-						const modules = chunk.getModules();
+						const modules = compilation.chunkGraph // WP5
+							? compilation.chunkGraph.getChunkModules(chunk)
+							: chunk.getModules();
 						const localizedModules = modules
 							.map(module => module.buildInfo.localized)
 							.filter(Boolean);


### PR DESCRIPTION
Example from a recent CI run: https://github.com/privatenumber/webpack-localize-assets-plugin/runs/4317919000?check_suite_focus=true#step:5:78