### PR TITLE
feat: allow filenames without [locale] in single locale

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,7 @@ class LocalizeAssetsPlugin<LocalizedData = string> {
 				}
 
 				if (this.singleLocale) {
-					interpolateLocaleToFileName(compilation, this.singleLocale, false);
+					interpolateLocaleToFileName(compilation, this.singleLocale);
 				} else {
 					/**
 					 * The reason why we replace "[locale]" with a placeholder instead of
@@ -118,7 +118,7 @@ class LocalizeAssetsPlugin<LocalizedData = string> {
 					 * The placeholder is a unique enough string to guarantee that we're not accidentally
 					 * replacing `[locale]` if it happens to be in the source JS.
 					 */
-					interpolateLocaleToFileName(compilation, fileNameTemplatePlaceholder);
+					interpolateLocaleToFileName(compilation, fileNameTemplatePlaceholder, true);
 
 					// Create localized assets by swapping out placeholders with localized strings
 					generateLocalizedAssets(

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,11 +105,7 @@ class LocalizeAssetsPlugin<LocalizedData = string> {
 				}
 
 				if (this.singleLocale) {
-					interpolateLocaleToFileName(
-						compilation,
-						this.singleLocale,
-						this.options.throwOnMissingLocaleInFileName,
-					);
+					interpolateLocaleToFileName(compilation, this.singleLocale, false);
 				} else {
 					/**
 					 * The reason why we replace "[locale]" with a placeholder instead of

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,11 @@ class LocalizeAssetsPlugin<LocalizedData = string> {
 				}
 
 				if (this.singleLocale) {
-					interpolateLocaleToFileName(compilation, this.singleLocale);
+					interpolateLocaleToFileName(
+						compilation,
+						this.singleLocale,
+						this.options.throwOnMissingLocaleInFileName,
+					);
 				} else {
 					/**
 					 * The reason why we replace "[locale]" with a placeholder instead of

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,6 @@ export type Options<LocalizedData = string> = {
 	throwOnMissing?: boolean;
 	sourceMapForLocales?: string[];
 	warnOnUnusedString?: boolean;
-	throwOnMissingLocaleInFileName?: boolean;
 } & LocalizeCompilerOption<LocalizedData>;
 
 type LocalizeCompilerOption<LocalizedData>

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export type Options<LocalizedData = string> = {
 	throwOnMissing?: boolean;
 	sourceMapForLocales?: string[];
 	warnOnUnusedString?: boolean;
+	throwOnMissingLocaleInFileName?: boolean;
 } & LocalizeCompilerOption<LocalizedData>;
 
 type LocalizeCompilerOption<LocalizedData>

--- a/src/utils/localize-filename.ts
+++ b/src/utils/localize-filename.ts
@@ -13,15 +13,18 @@ const { name } = require('../../package.json');
 export const interpolateLocaleToFileName = (
 	compilation: WP5.Compilation,
 	replaceWith: LocaleName,
+	throwOnMissingLocaleInFileName = true,
 ) => {
 	const { filename, chunkFilename } = compilation.outputOptions;
 
-	if (typeof filename === 'string') {
-		assert(filename.includes('[locale]'), 'output.filename must include [locale]');
-	}
+	if (throwOnMissingLocaleInFileName) {
+		if (typeof filename === 'string') {
+			assert(filename.includes('[locale]'), 'output.filename must include [locale]');
+		}
 
-	if (typeof chunkFilename === 'string') {
-		assert(chunkFilename.includes('[locale]'), 'output.chunkFilename must include [locale]');
+		if (typeof chunkFilename === 'string') {
+			assert(chunkFilename.includes('[locale]'), 'output.chunkFilename must include [locale]');
+		}
 	}
 
 	const interpolateHook = (

--- a/src/utils/localize-filename.ts
+++ b/src/utils/localize-filename.ts
@@ -13,11 +13,11 @@ const { name } = require('../../package.json');
 export const interpolateLocaleToFileName = (
 	compilation: WP5.Compilation,
 	replaceWith: LocaleName,
-	throwOnMissingLocaleInFileName = true,
+	shouldCheckFileName = true,
 ) => {
 	const { filename, chunkFilename } = compilation.outputOptions;
 
-	if (throwOnMissingLocaleInFileName) {
+	if (shouldCheckFileName) {
 		if (typeof filename === 'string') {
 			assert(filename.includes('[locale]'), 'output.filename must include [locale]');
 		}

--- a/src/utils/localize-filename.ts
+++ b/src/utils/localize-filename.ts
@@ -13,11 +13,11 @@ const { name } = require('../../package.json');
 export const interpolateLocaleToFileName = (
 	compilation: WP5.Compilation,
 	replaceWith: LocaleName,
-	shouldCheckFileName = true,
+	requireLocaleInFilename?: boolean,
 ) => {
 	const { filename, chunkFilename } = compilation.outputOptions;
 
-	if (shouldCheckFileName) {
+	if (requireLocaleInFilename) {
 		if (typeof filename === 'string') {
 			assert(filename.includes('[locale]'), 'output.filename must include [locale]');
 		}

--- a/tests/webpack-localize-assets-plugin.spec.ts
+++ b/tests/webpack-localize-assets-plugin.spec.ts
@@ -1128,6 +1128,57 @@ describe(`Webpack ${webpack.version}`, () => {
 		});
 	});
 
+	describe('throwOnMissingLocaleInFileName', () => {
+		test('single locale', async () => {
+			const built = await build(
+				{
+					'/src/index.js': 'export default __("hello-key");',
+				},
+				(config) => {
+					configureWebpack(config);
+
+					config.output.filename = '[name].js';
+					config.plugins.push(
+						new WebpackLocalizeAssetsPlugin({
+							locales: localesSingle,
+							throwOnMissingLocaleInFileName: false,
+						}),
+					);
+				},
+			);
+
+			const { assets } = built.stats.compilation;
+			expect(Object.keys(assets).length).toBe(1);
+
+			const enBuild = built.require('/dist/index.js');
+			expect(enBuild).toBe(localesMulti.en['hello-key']);
+
+			const statsOutput = built.stats.toString();
+			expect(statsOutput).toMatch(/index\.js/);
+		});
+
+		test('multi locale, option is ignored', async () => {
+			await expect(async () => {
+				await build(
+					{
+						'/src/index.js': 'export default __("hello-key");',
+					},
+					(config) => {
+						configureWebpack(config);
+
+						config.output.filename = '[name].js';
+						config.plugins.push(
+							new WebpackLocalizeAssetsPlugin({
+								locales: localesMulti,
+								throwOnMissingLocaleInFileName: false,
+							}),
+						);
+					},
+				);
+			}).rejects.toThrow('output.filename must include [locale]');
+		});
+	});
+
 	describe('chunkhash', () => {
 		test('single locale', async () => {
 			const volume = {

--- a/tests/webpack-localize-assets-plugin.spec.ts
+++ b/tests/webpack-localize-assets-plugin.spec.ts
@@ -413,8 +413,6 @@ describe(`Webpack ${webpack.version}`, () => {
 					'/src/index.js': 'export default __("hello-key");',
 				},
 				(config) => {
-					configureWebpack(config);
-
 					config.plugins.push(
 						new WebpackLocalizeAssetsPlugin({
 							locales: localesSingle,
@@ -426,11 +424,11 @@ describe(`Webpack ${webpack.version}`, () => {
 			const { assets } = built.stats.compilation;
 			expect(Object.keys(assets).length).toBe(1);
 
-			const enBuild = built.require('/dist/index.en.js');
+			const enBuild = built.require('/dist/index.js');
 			expect(enBuild).toBe(localesMulti.en['hello-key']);
 
 			const statsOutput = built.stats.toString();
-			expect(statsOutput).toMatch(/index\.en\.js/);
+			expect(statsOutput).toMatch(/index\.js/);
 		});
 
 		test('multi locale', async () => {
@@ -465,33 +463,6 @@ describe(`Webpack ${webpack.version}`, () => {
 			expect(statsOutput).toMatch(/index\.en\.js/);
 			expect(statsOutput).toMatch(/index\.es\.js/);
 			expect(statsOutput).toMatch(/index\.ja\.js/);
-		});
-
-		test('single locale without [locale] in filename', async () => {
-			const built = await build(
-				{
-					'/src/index.js': 'export default __("hello-key");',
-				},
-				(config) => {
-					configureWebpack(config);
-
-					config.output.filename = '[name].js';
-					config.plugins.push(
-						new WebpackLocalizeAssetsPlugin({
-							locales: localesSingle,
-						}),
-					);
-				},
-			);
-
-			const { assets } = built.stats.compilation;
-			expect(Object.keys(assets).length).toBe(1);
-
-			const enBuild = built.require('/dist/index.js');
-			expect(enBuild).toBe(localesMulti.en['hello-key']);
-
-			const statsOutput = built.stats.toString();
-			expect(statsOutput).toMatch(/index\.js/);
 		});
 
 		test('localize assets with chunks', async () => {


### PR DESCRIPTION
This PR add the option the ignore the `output.filename must include [locale]` warning on single locale builds, motivations described in #46.

When `throwOnMissingLocaleInFileName` is set to `false` AND there's only a single locale, the assertion is skipped. If there's more than one locale, the option is ignored and defaulted to `true`.

## Things I'm not sure about

- The handling of the default: right now is handled [here](https://github.com/nevnein/webpack-localize-assets-plugin/blob/7a615dd8419dad76bcf695a5e1ed6104982466dd/src/utils/localize-filename.ts#L16), I expected an object with default options (eventually overridden by user provided options) somewhere in the code but found none.
- Naming: Maybe too long?
- Tests: Wasn't quite sure were to put them so I just grouped them together