### PR TITLE
test: validate devtool eval output

### DIFF
--- a/tests/webpack-localize-assets-plugin.spec.ts
+++ b/tests/webpack-localize-assets-plugin.spec.ts
@@ -691,6 +691,10 @@ describe(`Webpack ${webpack.version}`, () => {
 			const { assets } = built.stats.compilation;
 
 			expect(Object.keys(assets)).toStrictEqual(['index.en.js', 'index.es.js', 'index.ja.js']);
+			
+			let enBuild = built.require('/dist/index.en.js');
+			
+			expect(enBuild).toBe('Hello');
 		});
 
 		test('emits source-maps', async () => {


### PR DESCRIPTION
Added a failing test for #49 issue

  ● Webpack 5.10.1 › passing › devtool eval

    fs-require://18C:\dist\index.en.js:17
    eval("/* harmony export */ __webpack_require__.d(__webpack_exports__, {\n/* harmony export */   \"default\": () => __WEBPACK_DEFAULT_EXPORT__\n/* harmony export */ });\n/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ("Hello");\n\n//# sourceURL=webpack:///./src/index.js?");
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    SyntaxError: missing ) after argument list

      693 |                     expect(Object.keys(assets)).toStrictEqual(['index.en.js', 'index.es.js', 'index.ja.js']);
      694 |
    > 695 |                     let enBuild = built.require('/dist/index.en.js');
          |                                         ^
      696 |                     expect(enBuild).toBe('Hello');
      697 |             });
      698 |

      at Object.<anonymous>.loaders. (node_modules/.pnpm/fs-require@1.4.0/node_modules/fs-require/dist/fs-require.js:23:18)
      at Object.require (node_modules/.pnpm/fs-require@1.4.0/node_modules/fs-require/dist/fs-require.js:58:96)
      at Object.<anonymous> (tests/webpack-localize-assets-plugin.spec.ts:695:24)