### PR TITLE
fix: escape double quotes in devtool eval

### DIFF
--- a/tests/webpack-localize-assets-plugin.spec.ts
+++ b/tests/webpack-localize-assets-plugin.spec.ts
@@ -674,7 +674,7 @@ describe(`Webpack ${webpack.version}`, () => {
 		test('devtool eval', async () => {
 			const built = await build(
 				{
-					'/src/index.js': 'export default __("hello-key");',
+					'/src/index.js': 'export default [__("hello-key"), __("stringWithQuotes")];',
 				},
 				(config) => {
 					configureWebpack(config);
@@ -691,10 +691,9 @@ describe(`Webpack ${webpack.version}`, () => {
 			const { assets } = built.stats.compilation;
 
 			expect(Object.keys(assets)).toStrictEqual(['index.en.js', 'index.es.js', 'index.ja.js']);
-			
-			let enBuild = built.require('/dist/index.en.js');
-			
-			expect(enBuild).toBe('Hello');
+
+			const enBuild = built.require('/dist/index.en.js');
+			expect(enBuild).toEqual([localesMulti.en['hello-key'], localesMulti.en.stringWithQuotes]);
 		});
 
 		test('emits source-maps', async () => {

--- a/tests/webpack-localize-assets-plugin.spec.ts
+++ b/tests/webpack-localize-assets-plugin.spec.ts
@@ -691,6 +691,10 @@ describe(`Webpack ${webpack.version}`, () => {
 			const { assets } = built.stats.compilation;
 
 			expect(Object.keys(assets)).toStrictEqual(['index.en.js', 'index.es.js', 'index.ja.js']);
+			
+			let enBuild = built.require('/dist/index.en.js');
+			
+			expect(enBuild).toBe('Hello');
 		});
 
 		test('emits source-maps', async () => {


### PR DESCRIPTION
closes https://github.com/privatenumber/webpack-localize-assets-plugin/issues/49