### PR TITLE
chore: use shell-emulator to run `test:wp5` on Windows

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+shell-emulator=true


### PR DESCRIPTION
> 5 might still fail since `WEBPACK=5` is UNIX env syntax. I'm hoping pnpm will resolve this as it spawns a [shell emulator](
https://pnpm.io/cli/run#shell-emulator).
> 
> If not, can you try creating a `.npmrc` file with:
> ```rc
> shell-emulator=true
> ```
> 
> Happy to accept PR if it works.

_Originally posted by @privatenumber in https://github.com/privatenumber/webpack-localize-assets-plugin/issues/56#issuecomment-1246940729_

With `shell-emulator=true` it works 🎉

Partial fix of #56 