### PR TITLE
test: clear webpack cache for windows paths

### DIFF
--- a/tests/webpack-localize-assets-plugin.spec.ts
+++ b/tests/webpack-localize-assets-plugin.spec.ts
@@ -939,7 +939,7 @@ describe(`Webpack ${webpack.version}`, () => {
 
 			expect(stats.hasWarnings()).toBe(false);
 
-			delete watching.require.cache['/dist/index.en.js'];
+			delete watching.require.cache[watching.require.resolve('/dist/index.en.js')];
 			enBuild = watching.require('/dist/index.en.js');
 			expect(enBuild).toBe('Hello World');
 
@@ -953,7 +953,7 @@ describe(`Webpack ${webpack.version}`, () => {
 			expect(warnings.length).toBe(1);
 			expect(warnings[0].message).toMatch('Missing localization for key "hello-key" used in /src/index.js:1:15 from locales: en');
 
-			delete watching.require.cache['/dist/index.en.js'];
+			delete watching.require.cache[watching.require.resolve('/dist/index.en.js')];
 			enBuild = watching.require('/dist/index.en.js');
 			expect(enBuild).toBe('hello-key World');
 


### PR DESCRIPTION
Clearing the cache was not working correctly on Windows. I added `resolve` like in the tests of [webpack-test-utils](https://github.com/privatenumber/webpack-test-utils/blob/0f1e38ebd6f4f5dc7226aa4a61df2466a90fe4d4/tests/webpack-test-utils.spec.ts#L70) and now it is working fine.

closes #56